### PR TITLE
specify arch in cache key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ runner.os == 'macOS' && '~/Library/Caches/hermit/pkg' || '~/.cache/hermit/pkg' }}
-        key: ${{ runner.os }}-hermit-cache-${{ steps.bin-hash.outputs.hash }}
+        key: ${{ runner.os }}-${{ runner.arch}}-hermit-cache-${{ steps.bin-hash.outputs.hash }}
         restore-keys: |
-          ${{ runner.os }}-hermit-cache-
+          ${{ runner.os }}-${{ runner.arch}}-hermit-cache-
     - shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: ./bin/hermit env --raw >> "$GITHUB_ENV"


### PR DESCRIPTION
This PR specifies the architecture in the cache key. This solves a bug where using `cache: true` on multiple cpu architectures of the same os can cause the cache to be poisoned